### PR TITLE
feat: use PORT env variable if provided instead of default (8080)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ pending plots are opened in a unique tab and all the data is requested, the
 server shuts down. If you fire another plot the server starts again provides
 your plot and shuts down automatically.
 
+Another port can be provided via PORT environment variable.
+
 ## Contributing
 
 Contributions in all forms are welcome.

--- a/src/plot.ts
+++ b/src/plot.ts
@@ -2,8 +2,8 @@ import { IPlot, IPlotsContainer } from './models/index';
 import { Layout, Plot } from './models/index';
 import { Server } from './server';
 
-
-const server = new Server(8080);
+const port = Number(process.env.PORT) || 8080;
+const server = new Server(port);
 
 export let plots: IPlot[] = [];
 export const plotContainer: IPlotsContainer = {};

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -2,7 +2,7 @@ import opn from 'opn';
 import request from 'request';
 import { Server } from '../src/server';
 
-const port = 8080;
+const port = Number(process.env.PORT) || 8080;
 const validData = {
   opened: false,
   pending: false,


### PR DESCRIPTION
I believe this change is useful and safe, taking in account the following:
1. Port 8080 is often in use.
2. Hardcoding is not a good practice (minor). 
3. It doesn't impact (I hope and tests are green :) previous version' behavior, so by default works the same way.

Closes #17
